### PR TITLE
fix scrypt import

### DIFF
--- a/scrypt.go
+++ b/scrypt.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"log"
 
-	"code.google.com/p/go.crypto/scrypt"
+	"golang.org/x/crypto/scrypt"
 )
 
 // DerivePassphrase returns a keylen_bytes+60 bytes of derived text


### PR DESCRIPTION
since the go packages moved away from code.google.com and the site is shutting down, the import should be fixed to point to the new repository location.
